### PR TITLE
fixed crash on next() just after snapshot_iter without iter(...)

### DIFF
--- a/tarantool_snapshot.c
+++ b/tarantool_snapshot.c
@@ -91,6 +91,8 @@ static int SnapshotIterator_init(SnapshotIterator *self, PyObject *args) {
         self->open_exception = 1;
         return 1;
     }
+
+    tnt_iter_storage(&(self->iter), &(self->stream));
     
     return 0;
 }


### PR DESCRIPTION
Initialize self->iter during snapshot_iter for prevent crash on "t.next()" without "iter(t)"
